### PR TITLE
Update ruby target to 2.7

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.2
+  TargetRubyVersion: 2.7
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes


### PR DESCRIPTION
Let's use a newer syntax ruby version for rubocop.